### PR TITLE
Publisere aktivitetsloggen på felles format. Introduserer PersonHende…

### DIFF
--- a/aktivitetslogg/src/main/kotlin/no/nav/dagpenger/aktivitetslogg/IAktivitetsloggMediator.kt
+++ b/aktivitetslogg/src/main/kotlin/no/nav/dagpenger/aktivitetslogg/IAktivitetsloggMediator.kt
@@ -7,7 +7,7 @@ interface PersonHendelse : Aktivitetskontekst, IAktivitetslogg {
     fun meldingsreferanseId(): String
 }
 
-interface IAktivitetsloggMediator {
+class AktivitetsloggEventMapper {
     fun håndter(personHendelse: PersonHendelse, publish: (AktivitetsLoggMelding) -> Unit) {
         publish(
             AktivitetsLoggMelding(

--- a/aktivitetslogg/src/main/kotlin/no/nav/dagpenger/aktivitetslogg/IAktivitetsloggMediator.kt
+++ b/aktivitetslogg/src/main/kotlin/no/nav/dagpenger/aktivitetslogg/IAktivitetsloggMediator.kt
@@ -2,15 +2,15 @@ package no.nav.dagpenger.aktivitetslogg
 
 import no.nav.dagpenger.aktivitetslogg.serde.AktivitetsloggJsonBuilder
 
-interface PersonHendelse : Aktivitetskontekst, IAktivitetslogg {
+interface AktivitetsloggHendelse  : Aktivitetskontekst, IAktivitetslogg {
     fun ident(): String
     fun meldingsreferanseId(): String
 }
 
 class AktivitetsloggEventMapper {
-    fun håndter(personHendelse: PersonHendelse, publish: (AktivitetsLoggMelding) -> Unit) {
+    fun håndter(personHendelse: AktivitetsloggHendelse, publish: (AktivitetsloggMelding) -> Unit) {
         publish(
-            AktivitetsLoggMelding(
+            AktivitetsloggMelding(
                 mapOf(
                     "hendelse" to mapOf(
                         "type" to personHendelse.toSpesifikkKontekst().kontekstType,
@@ -22,7 +22,7 @@ class AktivitetsloggEventMapper {
             )
         )
     }
-    data class AktivitetsLoggMelding(val innhold: Map<String, Any>) {
+    data class AktivitetsloggMelding(val innhold: Map<String, Any>) {
         val eventNavn: String = "aktivitetslogg"
     }
 }

--- a/aktivitetslogg/src/main/kotlin/no/nav/dagpenger/aktivitetslogg/IAktivitetsloggMediator.kt
+++ b/aktivitetslogg/src/main/kotlin/no/nav/dagpenger/aktivitetslogg/IAktivitetsloggMediator.kt
@@ -2,28 +2,27 @@ package no.nav.dagpenger.aktivitetslogg
 
 import no.nav.dagpenger.aktivitetslogg.serde.AktivitetsloggJsonBuilder
 
-
-interface AktivitetsloggMessageContext {
-    fun publish(eventNavn: String = "aktivitetslogg", message: Map<String, Any>)
-}
-
-interface AktivitetsloggHendelse : Subaktivitetskontekst {
+interface PersonHendelse : Aktivitetskontekst, IAktivitetslogg {
     fun ident(): String
     fun meldingsreferanseId(): String
 }
 
-
-interface IAktivitetsloggMediator : AktivitetsloggMessageContext {
-    fun publish(aktivitetsloggHendelse: AktivitetsloggHendelse) {
+interface IAktivitetsloggMediator {
+    fun håndter(personHendelse: PersonHendelse, publish: (AktivitetsLoggMelding) -> Unit) {
         publish(
-            message = mapOf(
-                "hendelse" to mapOf(
-                    "type" to aktivitetsloggHendelse.toSpesifikkKontekst().kontekstType,
-                    "meldingsreferanseId" to aktivitetsloggHendelse.meldingsreferanseId(),
-                ),
-                "ident" to aktivitetsloggHendelse.ident(),
-                "aktiviteter" to AktivitetsloggJsonBuilder(aktivitetsloggHendelse.aktivitetslogg).asList(),
+            AktivitetsLoggMelding(
+                mapOf(
+                    "hendelse" to mapOf(
+                        "type" to personHendelse.toSpesifikkKontekst().kontekstType,
+                        "meldingsreferanseId" to personHendelse.meldingsreferanseId(),
+                    ),
+                    "ident" to personHendelse.ident(),
+                    "aktiviteter" to AktivitetsloggJsonBuilder(personHendelse).asList(),
+                )
             )
         )
+    }
+    data class AktivitetsLoggMelding(val innhold: Map<String, Any>) {
+        val eventNavn: String = "aktivitetslogg"
     }
 }


### PR DESCRIPTION
…lse som en felles interface for å få med sporing av ident og meldingreferanseId

Første versjon av denne var ikke helt gjennomtenkt og lett å bruke.  


eksempel bruk: 

```kotlin
internal class AktivitetsloggMediator(private val rapidsConnection: RapidsConnection) {

    private val eventMapper = AktivitetsloggEventMapper()
    fun håndter(hendelse: Hendelse) {
        eventMapper.håndter(hendelse) { aktivitetLoggMelding ->
            rapidsConnection.publish(
                JsonMessage.newMessage(
                    aktivitetLoggMelding.eventNavn,
                    aktivitetLoggMelding.innhold,
                ).toJson(),
            )
        }
    }
}

```

og `hendelse` må være av type `PersonHendelse` 

```kotlin
abstract class Hendelse(
    private val meldingsreferanseId: UUID,
    private val ident: String,
    internal val aktivitetslogg: Aktivitetslogg,
) : PersonHendelse, IAktivitetslogg by aktivitetslogg { 

... 
``` 

